### PR TITLE
chore: use the correct branch in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Use `main` instead of `master`.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
